### PR TITLE
Statically compress CSV and cache invalidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,4 +108,4 @@ cms/staticfiles/
 envs.sh
 
 # Cached files
-schools.csv
+csv

--- a/cms/school_app/management/commands/writecsv.py
+++ b/cms/school_app/management/commands/writecsv.py
@@ -1,12 +1,15 @@
 import os
 import csv
 import time
+import gzip
+import brotli
 from django.core.management.base import BaseCommand
 from school_app.models import School
 
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
+        self.stdout.write('Generating CSV...')
         now = time.time()
         count = 0
         try:
@@ -24,3 +27,20 @@ class Command(BaseCommand):
                 count += 1
         self.stdout.write(self.style.SUCCESS(
             f'Wrote {count} records in {round(time.time()-now, 3)} seconds'))
+        # Generate compressed versions
+        with open('csv/schools.csv', 'rb') as f:
+            data = f.read()
+            # gzip
+            self.stdout.write('Compressing with gzip...')
+            now = time.time()
+            with gzip.open('csv/schools.csv.gz', 'wb') as g:
+                g.write(data)
+            self.stdout.write(self.style.SUCCESS(
+                f'Finished in {round(time.time()-now, 3)} seconds'))
+            # brotli
+            self.stdout.write('Compressing with brotli...')
+            now = time.time()
+            with open('csv/schools.csv.br', 'wb') as b:
+                b.write(brotli.compress(data, mode=brotli.MODE_TEXT))
+            self.stdout.write(self.style.SUCCESS(
+                f'Finished in {round(time.time()-now, 3)} seconds'))

--- a/cms/school_app/management/commands/writecsv.py
+++ b/cms/school_app/management/commands/writecsv.py
@@ -17,7 +17,8 @@ class Command(BaseCommand):
         except FileExistsError:
             # Folder already exists
             pass
-        with open('csv/schools.csv', 'w', encoding='utf-8-sig') as f:
+        # Write new files next to the old ones, then atomically replace
+        with open('csv/schools.csv.tmp', 'w', encoding='utf-8-sig') as f:
             field_names = School._meta.fields
             field_names = [str(field).split('.')[-1] for field in field_names]
             writer = csv.DictWriter(f, field_names)
@@ -28,19 +29,23 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS(
             f'Wrote {count} records in {round(time.time()-now, 3)} seconds'))
         # Generate compressed versions
-        with open('csv/schools.csv', 'rb') as f:
+        with open('csv/schools.csv.tmp', 'rb') as f:
             data = f.read()
             # gzip
             self.stdout.write('Compressing with gzip...')
             now = time.time()
-            with gzip.open('csv/schools.csv.gz', 'wb') as g:
+            with gzip.open('csv/schools.csv.gz.tmp', 'wb') as g:
                 g.write(data)
             self.stdout.write(self.style.SUCCESS(
                 f'Finished in {round(time.time()-now, 3)} seconds'))
             # brotli
             self.stdout.write('Compressing with brotli...')
             now = time.time()
-            with open('csv/schools.csv.br', 'wb') as b:
+            with open('csv/schools.csv.br.tmp', 'wb') as b:
                 b.write(brotli.compress(data, mode=brotli.MODE_TEXT))
             self.stdout.write(self.style.SUCCESS(
                 f'Finished in {round(time.time()-now, 3)} seconds'))
+        # Replace
+        os.replace('csv/schools.csv.tmp', 'csv/schools.csv')
+        os.replace('csv/schools.csv.gz.tmp', 'csv/schools.csv.gz')
+        os.replace('csv/schools.csv.br.tmp', 'csv/schools.csv.br')

--- a/cms/school_app/management/commands/writecsv.py
+++ b/cms/school_app/management/commands/writecsv.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
         count = 0
         try:
             os.mkdir('csv')
-        except OSError:
+        except FileExistsError:
             # Folder already exists
             pass
         with open('csv/schools.csv', 'w', encoding='utf-8-sig') as f:

--- a/cms/school_app/views.py
+++ b/cms/school_app/views.py
@@ -76,23 +76,19 @@ def SchoolListDownload(request):
         call_command('writecsv')
     encodings = [s.strip().upper()
                  for s in request.META['HTTP_ACCEPT_ENCODING'].split(',')]
-    print(encodings)
     if 'BR' in encodings:
         # Ideally serve brotli
-        print('Serving BR')
         response = FileResponse(
             open('csv/schools.csv.br', 'rb'), as_attachment=True, filename='schools.csv')
         response['Content-Encoding'] = 'br'
         response['Vary'] = 'Accept-Encoding'
     elif 'GZIP' in encodings:
-        print('Serving GZ')
         # Fallback on gzip
         response = FileResponse(
             open('csv/schools.csv.gz', 'rb'), as_attachment=True, filename='schools.csv')
         response['Content-Encoding'] = 'gzip'
         response['Vary'] = 'Accept-Encoding'
     else:
-        print('Serving text')
         # Fallback on no compression
         response = FileResponse(
             open('csv/schools.csv', 'rb'), as_attachment=True)


### PR DESCRIPTION
CSV disk cache now invalidates after 2 hours and will be regenerated.
Generates gzip and brotli compressed versions and serves those if browser accepts.
Closes #29.